### PR TITLE
Docstrings and Linting for syscallreplay codebase

### DIFF
--- a/syscallreplay/errno_dict.py
+++ b/syscallreplay/errno_dict.py
@@ -1,137 +1,146 @@
-""" Dictionary mapping string errno codes to their integer values
+""" 
+<Program Name>
+  errno_dict
+
+<Purpose>
+  Provides a dictionary that maps string errno codes to their integer values. This is useful
+  for system and socket call handlers to utilize when handling exit values, in the case that
+  the trace returns a non-zero value.
+
 """
+
 ERRNO_CODES = {
-    'EPERM': 1,  # Operation not permitted
-    'ENOENT': 2,  # No such file or directory
-    'ESRCH': 3,  # No such process
-    'EINTR': 4,  # Interrupted system call
-    'EIO': 5,  # I/O error
-    'ENXIO': 6,  # No such device or address
-    'E2BIG': 7,  # Argument list too long
-    'ENOEXEC': 8,  # Exec format error
-    'EBADF': 9,  # Bad file number
-    'ECHILD': 10,  # No child processes
-    'EAGAIN': 11,  # Try again
-    'ENOMEM': 12,  # Out of memory
-    'EACCES': 13,  # Permission denied
-    'EFAULT': 14,  # Bad address
-    'ENOTBLK': 15,  # Block device required
-    'EBUSY': 16,  # Device or resource busy
-    'EEXIST': 17,  # File exists
-    'EXDEV': 18,  # Cross-device link
-    'ENODEV': 19,  # No such device
-    'ENOTDIR': 20,  # Not a directory
-    'EISDIR': 21,  # Is a directory
-    'EINVAL': 22,  # Invalid argument
-    'ENFILE': 23,  # File table overflow
-    'EMFILE': 24,  # Too many open files
-    'ENOTTY': 25,  # Not a typewriter
-    'ETXTBSY': 26,  # Text file busy
-    'EFBIG': 27,  # File too large
-    'ENOSPC': 28,  # No space left on device
-    'ESPIPE': 29,  # Illegal seek
-    'EROFS': 30,  # Read-only file system
-    'EMLINK': 31,  # Too many links
-    'EPIPE': 32,  # Broken pipe
-    'EDOM': 33,  # Math argument out of domain of func
-    'ERANGE': 34,  # Math result not representable
-    'EDEADLK': 35,  # Resource deadlock would occur
-    'ENAMETOOLONG': 36,  # File name too long
-    'ENOLCK': 37,  # No record locks available
-    'ENOSYS': 38,  # Function not implemented
-    'ENOTEMPTY': 39,  # Directory not empty
-    'ELOOP': 40,  # Too many symbolic links encountered
-    'EWOULDBLOCK': 11,  # Operation would block
-    'ENOMSG': 42,  # No message of desired type
-    'EIDRM': 43,  # Identifier removed
-    'ECHRNG': 44,  # Channel number out of range
-    'EL2NSYNC': 45,  # Level 2 not synchronized
-    'EL3HLT': 46,  # Level 3 halted
-    'EL3RST': 47,  # Level 3 reset
-    'ELNRNG': 48,  # Link number out of range
-    'EUNATCH': 49,  # Protocol driver not attached
-    'ENOCSI': 50,  # No CSI structure available
-    'EL2HLT': 51,  # Level 2 halted
-    'EBADE': 52,  # Invalid exchange
-    'EBADR': 53,  # Invalid request descriptor
-    'EXFULL': 54,  # Exchange full
-    'ENOANO': 55,  # No anode
-    'EBADRQC': 56,  # Invalid request code
-    'EBADSLT': 57,  # Invalid slot
-    'EDEADLOCK': 35,
-    'EBFONT': 59,  # Bad font file format
-    'ENOSTR': 60,  # Device not a stream
-    'ENODATA': 61,  # No data available
-    'ETIME': 62,  # Timer expired
-    'ENOSR': 63,  # Out of streams resources
-    'ENONET': 64,  # Machine is not on the network
-    'ENOPKG': 65,  # Package not installed
-    'EREMOTE': 66,  # Object is remote
-    'ENOLINK': 67,  # Link has been severed
-    'EADV': 68,  # Advertise error
-    'ESRMNT': 69,  # Srmount error
-    'ECOMM': 70,  # Communication error on send
-    'EPROTO': 71,  # Protocol error
-    'EMULTIHOP': 72,  # Multihop attempted
-    'EDOTDOT': 73,  # RFS specific error
-    'EBADMSG': 74,  # Not a data message
-    'EOVERFLOW': 75,  # Value too large for defined data type
-    'ENOTUNIQ': 76,  # Name not unique on network
-    'EBADFD': 77,  # File descriptor in bad state
-    'EREMCHG': 78,  # Remote address changed
-    'ELIBACC': 79,  # Can not access a needed shared library
-    'ELIBBAD': 80,  # Accessing a corrupted shared library
-    'ELIBSCN': 81,  # .lib section in a.out corrupted
-    'ELIBMAX': 82,  # Attempting to link in too many shared libraries
-    'ELIBEXEC': 83,  # Cannot exec a shared library directly
-    'EILSEQ': 84,  # Illegal byte sequence
-    'ERESTART': 85,  # Interrupted system call should be restarted
-    'ESTRPIPE': 86,  # Streams pipe error
-    'EUSERS': 87,  # Too many users
-    'ENOTSOCK': 88,  # Socket operation on non-socket
-    'EDESTADDRREQ': 89,  # Destination address required
-    'EMSGSIZE': 90,  # Message too long
-    'EPROTOTYPE': 91,  # Protocol wrong type for socket
-    'ENOPROTOOPT': 92,  # Protocol not available
+    'EPERM': 1,             # Operation not permitted
+    'ENOENT': 2,            # No such file or directory
+    'ESRCH': 3,             # No such process
+    'EINTR': 4,             # Interrupted system call
+    'EIO': 5,               # I/O error
+    'ENXIO': 6,             # No such device or address
+    'E2BIG': 7,             # Argument list too long
+    'ENOEXEC': 8,           # Exec format error
+    'EBADF': 9,             # Bad file number
+    'ECHILD': 10,           # No child processes
+    'EAGAIN': 11,           # Try again
+    'ENOMEM': 12,           # Out of memory
+    'EACCES': 13,           # Permission denied
+    'EFAULT': 14,           # Bad address
+    'ENOTBLK': 15,          # Block device required
+    'EBUSY': 16,            # Device or resource busy
+    'EEXIST': 17,           # File exists
+    'EXDEV': 18,            # Cross-device link
+    'ENODEV': 19,           # No such device
+    'ENOTDIR': 20,          # Not a directory
+    'EISDIR': 21,           # Is a directory
+    'EINVAL': 22,           # Invalid argument
+    'ENFILE': 23,           # File table overflow
+    'EMFILE': 24,           # Too many open files
+    'ENOTTY': 25,           # Not a typewriter
+    'ETXTBSY': 26,          # Text file busy
+    'EFBIG': 27,            # File too large
+    'ENOSPC': 28,           # No space left on device
+    'ESPIPE': 29,           # Illegal seek
+    'EROFS': 30,            # Read-only file system
+    'EMLINK': 31,           # Too many links
+    'EPIPE': 32,            # Broken pipe
+    'EDOM': 33,             # Math argument out of domain of func
+    'ERANGE': 34,           # Math result not representable
+    'EDEADLK': 35,          # Resource deadlock would occur
+    'ENAMETOOLONG': 36,     # File name too long
+    'ENOLCK': 37,           # No record locks available
+    'ENOSYS': 38,           # Function not implemented
+    'ENOTEMPTY': 39,        # Directory not empty
+    'ELOOP': 40,            # Too many symbolic links encountered
+    'EWOULDBLOCK': 11,      # Operation would block
+    'ENOMSG': 42,           # No message of desired type
+    'EIDRM': 43,            # Identifier removed
+    'ECHRNG': 44,           # Channel number out of range
+    'EL2NSYNC': 45,         # Level 2 not synchronized
+    'EL3HLT': 46,           # Level 3 halted
+    'EL3RST': 47,           # Level 3 reset
+    'ELNRNG': 48,           # Link number out of range
+    'EUNATCH': 49,          # Protocol driver not attached
+    'ENOCSI': 50,           # No CSI structure available
+    'EL2HLT': 51,           # Level 2 halted
+    'EBADE': 52,            # Invalid exchange
+    'EBADR': 53,            # Invalid request descriptor
+    'EXFULL': 54,           # Exchange full
+    'ENOANO': 55,           # No anode
+    'EBADRQC': 56,          # Invalid request code
+    'EBADSLT': 57,          # Invalid slot
+    'EDEADLOCK': 35,        # Deadlock occurred
+    'EBFONT': 59,           # Bad font file format
+    'ENOSTR': 60,           # Device not a stream
+    'ENODATA': 61,          # No data available
+    'ETIME': 62,            # Timer expired
+    'ENOSR': 63,            # Out of streams resources
+    'ENONET': 64,           # Machine is not on the network
+    'ENOPKG': 65,           # Package not installed
+    'EREMOTE': 66,          # Object is remote
+    'ENOLINK': 67,          # Link has been severed
+    'EADV': 68,             # Advertise error
+    'ESRMNT': 69,           # Srmount error
+    'ECOMM': 70,            # Communication error on send
+    'EPROTO': 71,           # Protocol error
+    'EMULTIHOP': 72,        # Multihop attempted
+    'EDOTDOT': 73,          # RFS specific error
+    'EBADMSG': 74,          # Not a data message
+    'EOVERFLOW': 75,        # Value too large for defined data type
+    'ENOTUNIQ': 76,         # Name not unique on network
+    'EBADFD': 77,           # File descriptor in bad state
+    'EREMCHG': 78,          # Remote address changed
+    'ELIBACC': 79,          # Can not access a needed shared library
+    'ELIBBAD': 80,          # Accessing a corrupted shared library
+    'ELIBSCN': 81,          # .lib section in a.out corrupted
+    'ELIBMAX': 82,          # Attempting to link in too many shared libraries
+    'ELIBEXEC': 83,         # Cannot exec a shared library directly
+    'EILSEQ': 84,           # Illegal byte sequence
+    'ERESTART': 85,         # Interrupted system call should be restarted
+    'ESTRPIPE': 86,         # Streams pipe error
+    'EUSERS': 87,           # Too many users
+    'ENOTSOCK': 88,         # Socket operation on non-socket
+    'EDESTADDRREQ': 89,     # Destination address required
+    'EMSGSIZE': 90,         # Message too long
+    'EPROTOTYPE': 91,       # Protocol wrong type for socket
+    'ENOPROTOOPT': 92,      # Protocol not available
     'EPROTONOSUPPORT': 93,  # Protocol not supported
     'ESOCKTNOSUPPORT': 94,  # Socket type not supported
-    'EOPNOTSUPP': 95,  # Operation not supported on transport endpoint
-    'EPFNOSUPPORT': 96,  # Protocol family not supported
-    'EAFNOSUPPORT': 97,  # Address family not supported by protocol
-    'EADDRINUSE': 98,  # Address already in use
-    'EADDRNOTAVAIL': 99,  # Cannot assign requested address
-    'ENETDOWN': 100,  # Network is down
-    'ENETUNREACH': 101,  # Network is unreachable
-    'ENETRESET': 102,  # Network dropped connection because of reset
-    'ECONNABORTED': 103,  # Software caused connection abort
-    'ECONNRESET': 104,  # Connection reset by peer
-    'ENOBUFS': 105,  # No buffer space available
-    'EISCONN': 106,  # Transport endpoint is already connected
-    'ENOTCONN': 107,  # Transport endpoint is not connected
-    'ESHUTDOWN': 108,  # Cannot send after transport endpoint shutdown
-    'ETOOMANYREFS': 109,  # Too many references: cannot splice
-    'ETIMEDOUT': 110,  # Connection timed out
-    'ECONNREFUSED': 111,  # Connection refused
-    'EHOSTDOWN': 112,  # Host is down
-    'EHOSTUNREACH': 113,  # No route to host
-    'EALREADY': 114,  # Operation already in progress
-    'EINPROGRESS': 115,  # Operation now in progress
-    'ESTALE': 116,  # Stale file handle
-    'EUCLEAN': 117,  # Structure needs cleaning
-    'ENOTNAM': 118,  # Not a XENIX named type file
-    'ENAVAIL': 119,  # No XENIX semaphores available
-    'EISNAM': 120,  # Is a named type file
-    'EREMOTEIO': 121,  # Remote I/O error
-    'EDQUOT': 122,  # Quota exceeded
-    'ENOMEDIUM': 123,  # No medium found
-    'EMEDIUMTYPE': 124,  # Wrong medium type
-    'ECANCELED': 125,  # Operation Canceled
-    'ENOKEY': 126,  # Required key not available
-    'EKEYEXPIRED': 127,  # Key has expired
-    'EKEYREVOKED': 128,  # Key has been revoked
-    'EKEYREJECTED': 129,  # Key was rejected by service
-    'EOWNERDEAD': 130,  # Owner died
-    'ENOTRECOVERABLE': 131,  # State not recoverable
-    'ERFKILL': 132,  # Operation not possible due to RF-kill
-    'EHWPOISON': 133  # Memory page has hardware error
+    'EOPNOTSUPP': 95,       # Operation not supported on transport endpoint
+    'EPFNOSUPPORT': 96,     # Protocol family not supported
+    'EAFNOSUPPORT': 97,     # Address family not supported by protocol
+    'EADDRINUSE': 98,       # Address already in use
+    'EADDRNOTAVAIL': 99,    # Cannot assign requested address
+    'ENETDOWN': 100,        # Network is down
+    'ENETUNREACH': 101,     # Network is unreachable
+    'ENETRESET': 102,       # Network dropped connection because of reset
+    'ECONNABORTED': 103,    # Software caused connection abort
+    'ECONNRESET': 104,      # Connection reset by peer
+    'ENOBUFS': 105,         # No buffer space available
+    'EISCONN': 106,         # Transport endpoint is already connected
+    'ENOTCONN': 107,        # Transport endpoint is not connected
+    'ESHUTDOWN': 108,       # Cannot send after transport endpoint shutdown
+    'ETOOMANYREFS': 109,    # Too many references: cannot splice
+    'ETIMEDOUT': 110,       # Connection timed out
+    'ECONNREFUSED': 111,    # Connection refused
+    'EHOSTDOWN': 112,       # Host is down
+    'EHOSTUNREACH': 113,    # No route to host
+    'EALREADY': 114,        # Operation already in progress
+    'EINPROGRESS': 115,     # Operation now in progress
+    'ESTALE': 116,          # Stale file handle
+    'EUCLEAN': 117,         # Structure needs cleaning
+    'ENOTNAM': 118,         # Not a XENIX named type file
+    'ENAVAIL': 119,         # No XENIX semaphores available
+    'EISNAM': 120,          # Is a named type file
+    'EREMOTEIO': 121,       # Remote I/O error
+    'EDQUOT': 122,          # Quota exceeded
+    'ENOMEDIUM': 123,       # No medium found
+    'EMEDIUMTYPE': 124,     # Wrong medium type
+    'ECANCELED': 125,       # Operation Canceled
+    'ENOKEY': 126,          # Required key not available
+    'EKEYEXPIRED': 127,     # Key has expired
+    'EKEYREVOKED': 128,     # Key has been revoked
+    'EKEYREJECTED': 129,    # Key was rejected by service
+    'EOWNERDEAD': 130,      # Owner died
+    'ENOTRECOVERABLE': 131, # State not recoverable
+    'ERFKILL': 132,         # Operation not possible due to RF-kill
+    'EHWPOISON': 133        # Memory page has hardware error
 }

--- a/syscallreplay/getdents_parser.py
+++ b/syscallreplay/getdents_parser.py
@@ -1,8 +1,15 @@
-"""Code for parsing the structure returned by getdents as represented by
-strace's format.  posix-omni-parser fails entirely to deal with these
-structures so we fall back to manually dealing with the original line
+"""
+<Prgram Name>
+  getdents_parser
+
+<Purpose>
+  Code for parsing the structure returned by getdents as represented by
+  strace's format.  posix-omni-parser fails entirely to deal with these
+  structures so we fall back to manually dealing with the original line
+
 """
 
+# represents different flags for file types
 DIRENT_TYPES = {
     'DT_UNKNOWN': 0,
     'DT_FIFO': 1,
@@ -17,20 +24,47 @@ DIRENT_TYPES = {
 
 
 def parse_getdents_structure(syscall_object):
+    """
+    <Purpose>
+      Parses a getdents strace call and retrieves directory entries.
+
+    <Returns>
+    
+      if args is not None
+        entries:
+          A list of parsed directory entries from the getdents object
+      else:
+        Empty list
+
+    """
+
+    # checks if syscall_object is getdents call
     if 'getdents' not in syscall_object.name:
         raise ValueError('Received argument is not a getdents(64) syscall '
                          'object')
+
+    # return an empty list if no arguments were passed
     if syscall_object.args[1].value == '{}':
         return []
+
+    # parse entry by identifying brackets and seperators
     left_brace = syscall_object.original_line.find('{')
     right_brace = syscall_object.original_line.rfind('}')
-    line = syscall_object.original_line[left_brace+1:right_brace-1]
+    line = syscall_object.original_line[left_brace + 1:right_brace - 1]
     entries = line.split('}, {')
-
+    
+    # create a temporary list that adds entries based on comma delimiter,
+    # then copy over to actual entries list.
     tmp = []
     for i in entries:
         tmp += [i.split(', ')]
     entries = tmp
+
+    # break apart each entry, and create a dict to represent key and value
+    # for each attribute.
+    # i.e
+    #   d_ino=416894
+    #
     tmp = []
     tmp_dict = {}
     for i in entries:
@@ -43,14 +77,21 @@ def parse_getdents_structure(syscall_object):
         tmp_dict = {}
     entries = tmp
 
+    # parse attributes for each entry
     for i in entries:
+        # retrieve name of file
         i['d_name'] = i['d_name'].lstrip('"').rstrip('"')
+        
+        # check file type against DIRENT_TYPE
         try:
             i['d_type'] = DIRENT_TYPES[i['d_type']]
         except KeyError:
             raise NotImplementedError('Unsupported d_type: {}'
                                       .format(i['d_type']))
+
+        # identify other attributes and typecast as ints
         i['d_ino'] = int(i['d_ino'])
         i['d_reclen'] = int(i['d_reclen'])
         i['d_off'] = int(i['d_off'])
+
     return entries

--- a/syscallreplay/os_dict.py
+++ b/syscallreplay/os_dict.py
@@ -1,5 +1,12 @@
-"""Various dictionaies mapping pretty flags from strace to the values to which
-they correspond
+"""
+<Program Name>
+  os_dict
+
+<Purpose>
+  Provides various dictionaries mapping pretty flags from strace to the values 
+  to which they correspond. This allows other system call handlers that allow
+  to retrieve the proper flag from a seemingly generic strace value.
+
 """
 
 OS_CONST = {

--- a/syscallreplay/send_handlers.py
+++ b/syscallreplay/send_handlers.py
@@ -1,3 +1,13 @@
+"""
+<Program Name>
+  send_handlers
+
+<Purpose>
+  Provide system call handlers for send variants,
+  which provide data transfering mechanisms.
+
+"""
+
 import logging
 from util import (cint,
                   extract_socketcall_parameters,
@@ -7,7 +17,32 @@ from util import (cint,
 
 
 def sendfile_entry_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      sendfile call entry handler that always replays.
+      It does several things:
+      1. Validate the out and in fds, and the byte count
+      2. Noop out the current system call
+      3. Check offset argument
+      4. If offset is NULL, check
+      5. Set return value
+
+      Checks:
+      0: int out_fd - file descriptor for reading
+      1: int in_fd - file descriptor writing
+      3: size_t count - bytes written
+
+      Sets:
+      return value
+      errno
+
+    <Returns>
+      None
+    
+    """
     logging.debug('Entering sendfile entry handler')
+    
+    # validate file descriptors and count arg
     validate_integer_argument(pid, syscall_object, 0, 0)
     validate_integer_argument(pid, syscall_object, 1, 1)
     validate_integer_argument(pid, syscall_object, 3, 3)
@@ -19,18 +54,53 @@ def sendfile_entry_handler(syscall_id, syscall_object, pid):
     apply_return_conditions(pid, syscall_object)
 
 
+
+
+
 def send_entry_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      Send call entry handler that always replays. It does several 
+      things:
+      1. Peek ECX register for system call parametrs
+      2. Validate sockfd and message length
+      3. Noop out the current syscall
+      4. Set return value
+
+      Checks:
+      0: int sockfd: file descriptor or sending socket
+      2: size_t len: length of const void *buf
+
+      Sets:
+
+    <Returns>
+      None
+
+    """
     logging.debug('Entering send entry handler')
     ecx = cint.peek_register(pid, cint.ECX)
     params = extract_socketcall_parameters(pid, ecx, 3)
     validate_integer_argument(pid, syscall_object, 0, 0, params=params)
     validate_integer_argument(pid, syscall_object, 2, 2, params=params)
     trace_fd = int(syscall_object.args[0].value)
+    # TODO: compare trace fd against execution fd????
     noop_current_syscall(pid)
     apply_return_conditions(pid, syscall_object)
 
 
+
+
+
 def send_exit_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      send call exit handler that always replays. It checks the
+      return value from trace and execution.
+    
+    <Returns>
+      None
+
+    """
     logging.debug('Entering send exit handler')
     ret_val_from_trace = syscall_object.ret[0]
     ret_val_from_execution = cint.peek_register(pid, cint.EAX)
@@ -41,7 +111,25 @@ def send_exit_handler(syscall_id, syscall_object, pid):
                                        ret_val_from_trace))
 
 
+
+
+
 def sendto_entry_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      sendto call entry handler that replays based on fd from trace.
+      It does several things:
+      1. Peek ECX for system call parameters
+      2. Validate sockfd and message length
+      3. Check if replay is necessary based on fd from trace
+
+      Checks:
+      0: int sockfd 
+      2: size_t len
+
+    <Returns>
+      None
+    """
     logging.debug('Entering sendto entry handler')
     p = cint.peek_register(pid, cint.ECX)
     params = extract_socketcall_parameters(pid, p, 3)
@@ -57,10 +145,43 @@ def sendto_entry_handler(syscall_id, syscall_object, pid):
 
 
 def sendto_exit_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      sendto call exit handler. Does nothing at the moment.
+
+    <Returns>
+      None
+    """
     pass
 
 
+
+
+
 def sendmmsg_entry_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      sendmmsg call entry handler that replays based on trace sockfd.
+      It does several things:
+      1. Validate sockfd
+      2. Determine replay based on trace sockfd
+      3. Noop out the current system call if replay is necessary
+      4. Check return value to be successful when replaying, and retrieve
+      messages
+      5. Extract socketcall parameters, and retrieve address
+      6. TODO
+
+      Checks:
+      0: int sockfd: file descriptor of transmitting file descriptor
+
+      Sets:
+      return value
+      errno
+
+    <Returns>
+      None
+    
+    """
     logging.debug('Entering sendmmsg entry handler')
     sockfd_from_trace = syscall_object.args[0].value
     validate_integer_argument(pid, syscall_object, 0, 0)
@@ -93,5 +214,19 @@ def sendmmsg_entry_handler(syscall_id, syscall_object, pid):
         swap_trace_fd_to_execution_fd(pid, 0, syscall_object)
 
 
+
+
+
 def sendmmsg_exit_handler(syscall_id, syscall_object, pid):
+    """
+    <Purpose>
+      sendmmsg call exit handler. This is a placeholder
+
+    <Returns>
+      None
+    
+    """
+
+    # TODO: determine what needs to be implemented here
+    logging.debug('Entering sendmmsg exit handler')
     pass

--- a/syscallreplay/syscall_dict.py
+++ b/syscallreplay/syscall_dict.py
@@ -1,3 +1,13 @@
+"""
+<Program Name>
+  syscall_dict
+
+<Purpose>
+  Provides dictionaries that map both syscall and socketcall IDs to their respective
+  system call names.
+
+"""
+
 SYSCALLS = {
     0: 'sys_restart_syscall',
     1: 'sys_exit',


### PR DESCRIPTION
This is a PR that represents all of the linting and docstring additions that I have included within the syscallreplay codebase. I will be adding more commits to this, but I'm creating this for now to document what I have done so far.

1. Docstring and clean inline comment aligning for `*_dict.py` files.
2. Added documentation for `getdents_parser.py`
3. Added documentation for `send_handlers.py`
